### PR TITLE
equals e hashcode nas entidades author e book

### DIFF
--- a/spring-6-webapp/src/main/java/com/example/spring_6_webapp/domain/Author.java
+++ b/spring-6-webapp/src/main/java/com/example/spring_6_webapp/domain/Author.java
@@ -3,6 +3,7 @@ package com.example.spring_6_webapp.domain;
 
 import jakarta.persistence.*;
 
+import java.util.Objects;
 import java.util.Set;
 
 @Entity
@@ -47,5 +48,28 @@ public class Author {
 
     public void setLastName(String lastName) {
         this.lastName = lastName;
+    }
+
+
+    @Override
+    public String toString() {
+        return "Author{" +
+                "id=" + id +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", books=" + books +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Author author = (Author) o;
+        return Objects.equals(id, author.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/spring-6-webapp/src/main/java/com/example/spring_6_webapp/domain/Book.java
+++ b/spring-6-webapp/src/main/java/com/example/spring_6_webapp/domain/Book.java
@@ -2,6 +2,7 @@ package com.example.spring_6_webapp.domain;
 
 import jakarta.persistence.*;
 
+import java.util.Objects;
 import java.util.Set;
 
 @Entity
@@ -47,5 +48,28 @@ public class Book {
 
     public void setIsbn(String isbn) {
         this.isbn = isbn;
+    }
+
+
+    @Override
+    public String toString() {
+        return "Book{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", isbn='" + isbn + '\'' +
+                ", authors=" + authors +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        Book book = (Book) o;
+        return Objects.equals(id, book.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }


### PR DESCRIPTION
### Motivo
- garantir que o hibernate trate corretamente as entidades, evitando duplicados e inconsistências. 